### PR TITLE
Give permission to read contents so we can checkout repo

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      packages: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

Follow up to #3, discovered that if you set the `permission` key explicitly in the workflow the `GITHUB_TOKEN` that you get doesn't have permission to even checkout the repo.

This is explained in this GitHub Issue: https://github.com/actions/checkout/issues/254
