### PR TITLE
Use AWS credentials for ECR login

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -30,8 +30,6 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: public.ecr.aws
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers


### PR DESCRIPTION
## Description

When we moved to using ECR publishing instead of GHCR publishing, we did not remove the provision of credentials during the `docker/login-action` GH Action step. These were required by GHCR, but not in ECR.

We can see in [the previous ADOT Python Integration Workflow ECR Log In Step](https://github.com/aws-observability/aws-otel-python/blob/3ed757d39eb244940bc20f6a9437a76826bce06c/.github/workflows/integration-testing.yml#L40-L43) that there were no credentials provided.

Removing them should let us log in because we use the `Configure AWS Credentials` GH Action step right above it to get the credentials we need. This is mentioned in the [documentation for the docker/login-action GH Action](https://github.com/docker/login-action#aws-elastic-container-registry-ecr).