### PR TITLE
Fix sample app path for docker build

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -16,7 +16,7 @@ jobs:
         app-platform: [ ruby-on-rails ]
         instrumentation-type: [ manual ]
     env:
-      APP_PATH: integration-test-apps/${{ matrix.instrumentation-type}}-instrumentation/${{ matrix.app-platform }}
+      APP_PATH: sample-apps/${{ matrix.instrumentation-type}}-instrumentation/${{ matrix.app-platform }}
     steps:
       - name: Checkout This Repo
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description

Our Integration Testing was counting on the sample app being under the `integration-test-apps/` folder directory. However, that is the directory for the Python repo. Instead, we want it to be under the `sample-apps/` folder directory.

This PR fixes that so that the Docker build will succeed.