### PR TITLE
App Image must be under aws-otel-test ECR namespace

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -41,8 +41,7 @@ jobs:
             ${{ runner.os }}-buildx-
       - name: Construct Sample App image tag
         run: >
-          echo "APP_IMAGE=
-          public.ecr.aws/${{ github.repository }}/ruby-${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}:${{ github.sha }}
+          echo "APP_IMAGE=public.ecr.aws/aws-otel-test/ruby-${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}:${{ github.sha }}
           " |
           tee --append $GITHUB_ENV;
       - name: Build and Push Docker image


### PR DESCRIPTION
## Description

Our Integration Tests get a "403 forbidden" error when trying to push to public ECR.

I suspect this is because the app image has a leading " " before it. This is probably why [the latest Integration Workflow](https://github.com/aws-observability/aws-otel-ruby/runs/4945419885?check_suite_focus=true#step:8:371) says that it is trying to push to an empty image:

```
 #10 ERROR: unexpected status: 403 Forbidden
------
 > exporting to image:
------
```

We'll try removing the extra space from the Image Tag and try the Integration Test again.

EDIT: It might also be because we are not pushing to the `aws-otel-test/` namespaced repository. This is what [ADOT JS does](https://github.com/aws-observability/aws-otel-js/blob/74f3c6e5ee2133451722991cf7c360a888e8b555/.github/workflows/main.yml#L39) and it works for them, so we should do the same. The link is probably left over from GHCR.