### PR TITLE
Remove trailing space from Docker Image Tag

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -41,8 +41,7 @@ jobs:
             ${{ runner.os }}-buildx-
       - name: Construct Sample App image tag
         run: >
-          echo "APP_IMAGE=public.ecr.aws/aws-otel-test/ruby-${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}:${{ github.sha }}
-          " |
+          echo "APP_IMAGE=public.ecr.aws/aws-otel-test/ruby-${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}:${{ github.sha }}" |
           tee --append $GITHUB_ENV;
       - name: Build and Push Docker image
         uses: docker/build-push-action@v2


### PR DESCRIPTION
## Description

Follow up to #8, not only are leading spaces not allowed, trailing spaces are also not allowed.

Instead of failing to push, `docker-compose` fails to pull the image if it has this trailing space as discussed in [this StackOverflow post](https://stackoverflow.com/questions/47435418/docker-command-returns-invalid-reference-format).

We remove the trailing space from the image in this PR.
