### PR TITLE
Add Soak Tests to ADOT Ruby repo

### DIFF
--- a/.github/auto-issue-templates/failure-after-soak_tests.md
+++ b/.github/auto-issue-templates/failure-after-soak_tests.md
@@ -1,0 +1,17 @@
+---
+title: Performance Threshold breached AFTER Soak Tests completed for the ({{ env.APP_PLATFORM }}, {{ env.INSTRUMENTATION_TYPE }}) Sample App
+# assignees: open-telemetry/opentelemetry-<LANGUAGE>-approvers
+labels: bug #, enhancement
+---
+# Description
+
+After the Soak Tests completed, a performance degradation was revealed for commit {{ sha }} of the `{{ ref }}` branch for the ({{ env.APP_PLATFORM }}, {{ env.INSTRUMENTATION_TYPE }}) Sample App. Check out the Action Logs from the `{{ workflow }}` [workflow run on GitHub]({{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}) to view the threshold violation.
+
+# Useful Links
+
+Snapshots of the Soak Test run are available [on the gh-pages branch](https://github.com/{{ env.GITHUB_REPOSITORY }}/tree/gh-pages/soak-tests/snapshots/commits/{{ sha }}). These are the snapshots for the violating commit:
+
+![CPU Load Soak Test SnapShot Image](https://github.com/{{ env.GITHUB_REPOSITORY }}/blob/gh-pages/soak-tests/snapshots/commits/{{ sha }}/runs/{{ env.GITHUB_RUN_ID }}/{{ env.APP_PLATFORM }}/{{ env.INSTRUMENTATION_TYPE }}-cpu-load.png?raw=true)
+![Total Memory Soak Test SnapShot Image](https://github.com/{{ env.GITHUB_REPOSITORY }}/blob/gh-pages/soak-tests/snapshots/commits/{{ sha }}/runs/{{ env.GITHUB_RUN_ID }}/{{ env.APP_PLATFORM }}/{{ env.INSTRUMENTATION_TYPE }}-total-memory.png?raw=true)
+
+The threshold violation should also be noticeable on [our graph of Soak Test average results per commit](https://{{ repo.owner }}.github.io/{{ repo.repo }}/soak-tests/per-commit-overall-results/index.html).

--- a/.github/auto-issue-templates/failure-during-soak_tests.md
+++ b/.github/auto-issue-templates/failure-during-soak_tests.md
@@ -1,0 +1,15 @@
+---
+title: Performance Threshold breached DURING Soak Tests execution for the ({{ env.APP_PLATFORM }}, {{ env.INSTRUMENTATION_TYPE }}) Sample App
+# assignees: open-telemetry/opentelemetry-<LANGUAGE>-approvers
+labels: bug #, enhancement
+---
+# Description
+
+During Soak Tests execution, a performance degradation was revealed for commit {{ sha }} of the `{{ ref }}` branch for the ({{ env.APP_PLATFORM }}, {{ env.INSTRUMENTATION_TYPE }}) Sample App. Check out the Action Logs from the `{{ workflow }}` [workflow run on GitHub]({{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}) to view the threshold violation.
+
+# Useful Links
+
+Snapshots of the Soak Test run are available [on the gh-pages branch](https://github.com/{{ env.GITHUB_REPOSITORY }}/tree/gh-pages/soak-tests/snapshots/commits/{{ sha }}). These are the snapshots for the violating commit:
+
+![CPU Load Soak Test SnapShot Image](https://github.com/{{ env.GITHUB_REPOSITORY }}/blob/gh-pages/soak-tests/snapshots/commits/{{ sha }}/runs/{{ env.GITHUB_RUN_ID }}/{{ env.APP_PLATFORM }}/{{ env.INSTRUMENTATION_TYPE }}-cpu-load.png?raw=true)
+![Total Memory Soak Test SnapShot Image](https://github.com/{{ env.GITHUB_REPOSITORY }}/blob/gh-pages/soak-tests/snapshots/commits/{{ sha }}/runs/{{ env.GITHUB_RUN_ID }}/{{ env.APP_PLATFORM }}/{{ env.INSTRUMENTATION_TYPE }}-total-memory.png?raw=true)

--- a/.github/docker-performance-tests/alarms-poller/Dockerfile
+++ b/.github/docker-performance-tests/alarms-poller/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.9
+
+COPY . .
+
+RUN pip install docker boto3
+
+CMD python ./poll_during_performance_tests.py --logs-namespace $LOGS_NAMESPACE \
+                                              --metrics-period $HOSTMETRICS_INTERVAL_SECS \
+                                              --num-of-cpus $NUM_OF_CPUS \
+                                              --app-process-command-line-dimension-value "$APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE" \
+                                              --target-sha $TARGET_SHA \
+                                              --github-run-id $GITHUB_RUN_ID \
+                                              --cpu-load-threshold $CPU_LOAD_THRESHOLD \
+                                              --total-memory-threshold $TOTAL_MEMORY_THRESHOLD \
+                                              --matrix-commit-combo $MATRIX_COMMIT_COMBO

--- a/.github/docker-performance-tests/alarms-poller/metric_data_params.py
+++ b/.github/docker-performance-tests/alarms-poller/metric_data_params.py
@@ -1,0 +1,199 @@
+import argparse
+
+# AWS Client API Constants
+
+COMMIT_SHA_DIMENSION_NAME = "commit_sha"
+GITHUB_RUN_ID_DIMENSION_NAME = "github_run_id"
+PROCESS_COMMAND_LINE_DIMENSION_NAME = "process.command_line"
+
+METRIC_DATA_STATISTIC = "Sum"
+
+
+def add_arguments(parser: argparse.ArgumentParser):
+    parser.add_argument(
+        "--logs-namespace",
+        required=True,
+        help="""
+        The namespace of the logs that the alarm should poll.
+
+        Examples:
+
+            --logs-namespace=aws-observability/aws-otel-python/soak-tests
+        """,
+    )
+
+    parser.add_argument(
+        "--metrics-period",
+        required=True,
+        type=int,
+        help="""
+        The interval at which performance metrics are collected. This is the
+        period used for the metrics monitored by the alarms and is the interval
+        with which the script polls the Performance Test alarms (in seconds).
+
+        Examples:
+
+            --metrics-period=600
+        """,
+    )
+
+    parser.add_argument(
+        "--num-of-cpus",
+        required=True,
+        type=int,
+        help="""
+        The number of CPUs used when running the performance tests.
+
+        Examples:
+
+            --num-of-cpus=2
+        """,
+    )
+
+    parser.add_argument(
+        "--app-process-command-line-dimension-value",
+        required=True,
+        help="""
+        The Cloudwatch metric dimension value which corresponds to the command
+        line string used to run the sample app process. This sample app is the
+        one being tested for performance. The alarms being polled in this script
+        monitor metrics which contain this dimension value.
+
+        Examples:
+
+            --app-process-command-line-dimension-value='/usr/local/bin/python3 application.py'
+        """,
+    )
+
+    parser.add_argument(
+        "--target-sha",
+        required=True,
+        help="""
+        The SHA of the commit for the current GitHub workflow run. Used to
+        query Cloudwatch by metric dimension value so metrics returned
+        correspond to the app that was performance tested.
+
+        Examples:
+
+            --target-sha=${{ github.sha }}
+        """,
+    )
+
+    parser.add_argument(
+        "--github-run-id",
+        required=True,
+        help="""
+        The Id for the current GitHub workflow run. Used as a dimension by which
+        metrics are queried in Cloudwatch by so that metrics returned correspond
+        to the correct run of the app that was performance tested.
+
+        Examples:
+
+            --github-run-id=$GITHUB_RUN_ID
+        """,
+    )
+
+
+def get_metric_data_params(args):
+    cpu_load_metric_data_queries = [
+        {
+            "Id": "cpu_time_raw",
+            "MetricStat": {
+                "Metric": {
+                    "Namespace": args.logs_namespace,
+                    "MetricName": "process.cpu.time",
+                    "Dimensions": [
+                        {
+                            "Name": PROCESS_COMMAND_LINE_DIMENSION_NAME,
+                            "Value": args.app_process_command_line_dimension_value,
+                        },
+                        {
+                            "Name": COMMIT_SHA_DIMENSION_NAME,
+                            "Value": args.target_sha,
+                        },
+                        {
+                            "Name": GITHUB_RUN_ID_DIMENSION_NAME,
+                            "Value": args.github_run_id,
+                        },
+                    ],
+                },
+                "Stat": METRIC_DATA_STATISTIC,
+                "Period": args.metrics_period,
+            },
+            "Label": "CPU Time Raw",
+            "ReturnData": False,
+        },
+        {
+            "Id": "cpu_load_expr",
+            "Expression": f"cpu_time_raw/PERIOD(cpu_time_raw)/{args.num_of_cpus}*100",
+            "Label": f"CPU Load Percentage for {args.num_of_cpus} CPUs",
+            "ReturnData": True,
+            "Period": args.metrics_period,
+        },
+    ]
+
+    total_memory_metric_data_queries = [
+        {
+            "Id": "virtual_memory_raw",
+            "MetricStat": {
+                "Metric": {
+                    "Namespace": args.logs_namespace,
+                    "MetricName": "process.memory.virtual_usage",
+                    "Dimensions": [
+                        {
+                            "Name": PROCESS_COMMAND_LINE_DIMENSION_NAME,
+                            "Value": args.app_process_command_line_dimension_value,
+                        },
+                        {
+                            "Name": COMMIT_SHA_DIMENSION_NAME,
+                            "Value": args.target_sha,
+                        },
+                        {
+                            "Name": GITHUB_RUN_ID_DIMENSION_NAME,
+                            "Value": args.github_run_id,
+                        },
+                    ],
+                },
+                "Stat": METRIC_DATA_STATISTIC,
+                "Period": args.metrics_period,
+            },
+            "Label": "Virtual Memory",
+            "ReturnData": False,
+        },
+        {
+            "Id": "physical_memory_raw",
+            "MetricStat": {
+                "Metric": {
+                    "Namespace": args.logs_namespace,
+                    "MetricName": "process.memory.physical_usage",
+                    "Dimensions": [
+                        {
+                            "Name": PROCESS_COMMAND_LINE_DIMENSION_NAME,
+                            "Value": args.app_process_command_line_dimension_value,
+                        },
+                        {
+                            "Name": COMMIT_SHA_DIMENSION_NAME,
+                            "Value": args.target_sha,
+                        },
+                        {
+                            "Name": GITHUB_RUN_ID_DIMENSION_NAME,
+                            "Value": args.github_run_id,
+                        },
+                    ],
+                },
+                "Stat": METRIC_DATA_STATISTIC,
+                "Period": args.metrics_period,
+            },
+            "Label": "Physical Memory",
+            "ReturnData": False,
+        },
+        {
+            "Id": "total_memory_expr",
+            "Expression": "SUM([virtual_memory_raw])",
+            "Label": "Total Memory",
+            "ReturnData": True,
+            "Period": args.metrics_period,
+        },
+    ]
+
+    return cpu_load_metric_data_queries, total_memory_metric_data_queries

--- a/.github/docker-performance-tests/alarms-poller/poll_during_performance_tests.py
+++ b/.github/docker-performance-tests/alarms-poller/poll_during_performance_tests.py
@@ -1,0 +1,227 @@
+import argparse
+import logging
+import sys
+import time
+
+import boto3
+import docker
+
+import metric_data_params
+
+logging.basicConfig(
+    format="%(asctime)-8s %(levelname)-8s %(message)s",
+    level=logging.INFO,
+    datefmt="%FT%TZ",
+)
+
+logger = logging.getLogger(__file__)
+
+# AWS Client API Constants
+
+COMMON_ALARM_API_PARAMETERS = {
+    "EvaluationPeriods": 5,
+    "DatapointsToAlarm": 5,
+    "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+    "TreatMissingData": "ignore",
+}
+
+CPU_LOAD_ALARM_NAME_PREFIX = "OTel Performance Test - CPU Load Percentage Spike"
+TOTAL_MEMORY_ALARM_NAME_PREFIX = (
+    "OTel Performance Test - Virtual Memory Usage Spike"
+)
+
+# Docker Client API Constants
+
+APP_CONTAINER_NAME = "docker-performance-tests_app_1"
+COLLECTOR_CONTAINER_NAME = "docker-performance-tests_otel_1"
+LOAD_GENERATOR_CONTAINER_NAME = "docker-performance-tests_load-generator_1"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="""
+        poll_during_performance_tests.py continuously polls the backend monitoring tool
+        to see if an alarm has triggered because of a spike in the Performance Tests.
+        """
+    )
+
+    metric_data_params.add_arguments(parser)
+
+    parser.add_argument(
+        "--cpu-load-threshold",
+        required=True,
+        type=int,
+        help="""
+        The threshold the CPU Load (as a percentage) must stay under to not
+        trigger the alarm.
+
+        Examples:
+
+            --cpu-load-threshold=75
+        """,
+    )
+
+    parser.add_argument(
+        "--total-memory-threshold",
+        required=True,
+        type=int,
+        help="""
+        The threshold the Total Memory (in bytes) must stay under to not trigger
+        the alarm.
+
+        Examples:
+
+            --total-memory-threshold=$(echo 1.5 \* 2^30 | bc)
+        """,
+    )
+
+    parser.add_argument(
+        "--matrix-commit-combo",
+        required=True,
+        help="""
+        The matrix + commit combination which uniquely defines this Sample app
+        by its platform used, its instrumentation type, and the commit SHA from
+        which it was built. Used to create a unique name for the Performance
+        Test Alarms.
+
+        Examples:
+
+            --matrix-commit-combo=flask-auto-12345abcdef38e38678a59da0911c9abcde12345
+        """,
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    logger.debug("Starting Alarm Polling Script.")
+
+    docker_client = docker.from_env()
+
+    try:
+        if (
+            docker_client.containers.get(APP_CONTAINER_NAME).attrs["State"][
+                "Status"
+            ]
+            != "running"
+        ):
+            raise Exception("Failing because Sample App was not running.")
+
+        if (
+            docker_client.containers.get(COLLECTOR_CONTAINER_NAME).attrs[
+                "State"
+            ]["Status"]
+            != "running"
+        ):
+            raise Exception("Failing because Collector was not running.")
+
+        if (
+            docker_client.containers.get(LOAD_GENERATOR_CONTAINER_NAME).attrs[
+                "State"
+            ]["Status"]
+            != "running"
+        ):
+            raise Exception("Failing because Load Generator was not running.")
+
+        args = parse_args()
+
+        (
+            cpu_load_metric_data_queries,
+            total_memory_metric_data_queries,
+        ) = metric_data_params.get_metric_data_params(args)
+
+        aws_client = boto3.client("cloudwatch")
+
+        unique_alarm_name_component = (
+            f"{args.matrix_commit_combo}-{args.github_run_id}"
+        )
+
+        cpu_load_alarm_name = f"{CPU_LOAD_ALARM_NAME_PREFIX} ({unique_alarm_name_component}) Sample App"
+        total_memory_alarm_name = f"{TOTAL_MEMORY_ALARM_NAME_PREFIX} ({unique_alarm_name_component}) Sample App"
+
+        # Delete Alarms
+
+        aws_client.delete_alarms(
+            AlarmNames=[cpu_load_alarm_name, total_memory_alarm_name]
+        )
+
+        # Create Alarms
+
+        aws_client.put_metric_alarm(
+            **{
+                **COMMON_ALARM_API_PARAMETERS,
+                "AlarmName": cpu_load_alarm_name,
+                "AlarmDescription": "Triggers when the CPU Load Percentage spikes above the allowed threshold DURING the ({unique_alarm_name_component}) Sample App Performance Test.",
+                "Threshold": args.cpu_load_threshold,
+                "Metrics": cpu_load_metric_data_queries,
+            }
+        )
+
+        aws_client.put_metric_alarm(
+            **{
+                **COMMON_ALARM_API_PARAMETERS,
+                "AlarmName": total_memory_alarm_name,
+                "AlarmDescription": "Triggers when the Virtual Memory Usage spikes above the allowed threshold DURING the ({unique_alarm_name_component}) Sample App Performance Test.",
+                "Threshold": args.total_memory_threshold,
+                "Metrics": total_memory_metric_data_queries,
+            }
+        )
+
+        # Poll Alarms
+
+        did_tests_fail_during_execution = False
+        time_of_last_alarm_poll = time.time()
+
+        logger.info(
+            "Begin polling alarms. Continue until Load Generator completes."
+        )
+
+        while (
+            docker_client.containers.get(LOAD_GENERATOR_CONTAINER_NAME).attrs[
+                "State"
+            ]["Status"]
+            == "running"
+        ):
+            if time.time() - time_of_last_alarm_poll > args.metrics_period:
+                logger.info("Polling alarms now.")
+                for alarm in aws_client.describe_alarms(
+                    AlarmNames=[
+                        cpu_load_alarm_name,
+                        total_memory_alarm_name,
+                    ]
+                )["MetricAlarms"]:
+                    alarm_desc = (
+                        f"Alarm {alarm['AlarmName']} was {alarm['StateValue']} with reason: {alarm['StateReason']}.",
+                    )
+                    if alarm["StateValue"] == "ALARM":
+                        logger.error(alarm_desc)
+                        did_tests_fail_during_execution = True
+                    else:
+                        logger.info(alarm_desc)
+                time_of_last_alarm_poll = time.time()
+
+            time.sleep(3)
+
+        logger.info("Done polling Performance Test alarms.")
+
+        # Delete Alarms
+
+        aws_client.delete_alarms(
+            AlarmNames=[cpu_load_alarm_name, total_memory_alarm_name]
+        )
+
+        # End the Polling
+
+        if did_tests_fail_during_execution:
+            logger.error(
+                "Failing because of alarms triggered during Performance Test."
+            )
+            sys.exit(2)
+
+    finally:
+        for container_name in [
+            APP_CONTAINER_NAME,
+            LOAD_GENERATOR_CONTAINER_NAME,
+            COLLECTOR_CONTAINER_NAME,
+        ]:
+            docker_client.containers.get(container_name).stop()

--- a/.github/docker-performance-tests/docker-compose.yml
+++ b/.github/docker-performance-tests/docker-compose.yml
@@ -1,0 +1,74 @@
+version: "3.7"
+services:
+  otel:
+    image: otel/opentelemetry-collector-contrib:latest
+    command: --config /otel-collector/collector-config.yml
+    environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
+      - AWS_DEFAULT_REGION
+      - TARGET_SHA
+      - GITHUB_RUN_ID
+      - HOSTMETRICS_INTERVAL_SECS
+      - LOG_GROUP_NAME
+      - LOGS_NAMESPACE
+      - MATRIX_COMMIT_COMBO
+      - APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE
+      - APP_PROCESS_EXECUTABLE_NAME
+    volumes:
+      - ./otel-collector:/otel-collector
+      - type: bind
+        source: /proc
+        target: /proc
+    ports:
+      - '4317:4317'
+    user: "${UID}:${GID}"
+
+  app:
+    build:
+      context: ../../${APP_PATH}
+    environment:
+      - INSTANCE_ID
+      - LISTEN_ADDRESS=0.0.0.0:${LISTEN_ADDRESS_PORT}
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
+      - AWS_DEFAULT_REGION
+      - SAMPLE_APP_LOG_LEVEL=ERROR
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=aws-otel-integ-test
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel:4317
+    ports:
+      - '${LISTEN_ADDRESS_PORT}:${LISTEN_ADDRESS_PORT}'
+
+  load-generator:
+    build:
+      context: ./load-generator
+    environment:
+      - TARGET_ADDRESS=app:${LISTEN_ADDRESS_PORT}
+      - TEST_DURATION_MINUTES
+    depends_on:
+      - otel
+      - app
+
+  alarms-poller:
+    build:
+      context: ./alarms-poller
+    environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
+      - AWS_DEFAULT_REGION
+      - HOSTMETRICS_INTERVAL_SECS
+      - NUM_OF_CPUS
+      - TARGET_SHA
+      - LOGS_NAMESPACE
+      - APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE
+      - CPU_LOAD_THRESHOLD
+      - TOTAL_MEMORY_THRESHOLD
+      - GITHUB_RUN_ID
+      - MATRIX_COMMIT_COMBO
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - load-generator

--- a/.github/docker-performance-tests/load-generator/Dockerfile
+++ b/.github/docker-performance-tests/load-generator/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.16-alpine
+
+ADD https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64 /usr/local/bin/hey
+
+RUN chmod +x /usr/local/bin/hey
+
+CMD hey -z "$TEST_DURATION_MINUTES"m http://"$TARGET_ADDRESS"/outgoing-http-call

--- a/.github/docker-performance-tests/otel-collector/collector-config.yml
+++ b/.github/docker-performance-tests/otel-collector/collector-config.yml
@@ -1,0 +1,82 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+  hostmetrics:
+    collection_interval: ${HOSTMETRICS_INTERVAL_SECS}s
+    scrapers:
+      process:
+        include:
+          match_type: strict
+          names:
+            - ${APP_PROCESS_EXECUTABLE_NAME}
+
+processors:
+  filter:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+          - process.cpu.time
+          # TODO: Add this if we want Disk stats in the future
+          # - process.disk.io
+          - process.memory.physical_usage
+          - process.memory.virtual_usage
+        resource_attributes:
+          - Key: process.command_line
+            Value: ${APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE}
+  metricstransform:
+    transforms:
+      - include: process.*
+        match_type: regexp
+        action: update
+        operations:
+          - action: add_label
+            new_label: commit_sha
+            new_value: ${TARGET_SHA}
+          - action: add_label
+            new_label: github_run_id
+            new_value: ${GITHUB_RUN_ID}
+
+exporters:
+  logging:
+    loglevel: error
+  awsemf:
+    region: ${AWS_DEFAULT_REGION}
+    namespace: ${LOGS_NAMESPACE}
+    log_group_name: ${LOG_GROUP_NAME}
+    log_stream_name: sample-app-${MATRIX_COMMIT_COMBO}
+    resource_to_telemetry_conversion:
+      enabled: true
+    dimension_rollup_option: NoDimensionRollup
+    metric_declarations:
+      - dimensions: [
+          [
+            process.command_line,
+            commit_sha,
+            github_run_id
+          ]
+        ]
+        metric_name_selectors:
+          - process.cpu.time
+          # - process.disk.io
+          - process.memory.physical_usage
+          - process.memory.virtual_usage
+
+service:
+  pipelines:
+    traces:
+      receivers:
+        - otlp
+      exporters:
+        - logging
+    metrics:
+      receivers:
+        - hostmetrics
+        - otlp
+      processors:
+        - filter
+        - metricstransform
+      exporters:
+        - awsemf

--- a/.github/performance-tests/get-metric-data/metric_data_params.py
+++ b/.github/performance-tests/get-metric-data/metric_data_params.py
@@ -1,0 +1,199 @@
+import argparse
+
+# AWS Client API Constants
+
+COMMIT_SHA_DIMENSION_NAME = "commit_sha"
+GITHUB_RUN_ID_DIMENSION_NAME = "github_run_id"
+PROCESS_COMMAND_LINE_DIMENSION_NAME = "process.command_line"
+
+METRIC_DATA_STATISTIC = "Sum"
+
+
+def add_arguments(parser: argparse.ArgumentParser):
+    parser.add_argument(
+        "--logs-namespace",
+        required=True,
+        help="""
+        The namespace of the logs that the alarm should poll.
+
+        Examples:
+
+            --logs-namespace=aws-observability/aws-otel-python/soak-tests
+        """,
+    )
+
+    parser.add_argument(
+        "--metrics-period",
+        required=True,
+        type=int,
+        help="""
+        The interval at which performance metrics are collected. This is the
+        period used for the metrics monitored by the alarms and is the interval
+        with which the script polls the Performance Test alarms (in seconds).
+
+        Examples:
+
+            --metrics-period=600
+        """,
+    )
+
+    parser.add_argument(
+        "--num-of-cpus",
+        required=True,
+        type=int,
+        help="""
+        The number of CPUs used when running the performance tests.
+
+        Examples:
+
+            --num-of-cpus=2
+        """,
+    )
+
+    parser.add_argument(
+        "--app-process-command-line-dimension-value",
+        required=True,
+        help="""
+        The Cloudwatch metric dimension value which corresponds to the command
+        line string used to run the sample app process. This sample app is the
+        one being tested for performance. The alarms being polled in this script
+        monitor metrics which contain this dimension value.
+
+        Examples:
+
+            --app-process-command-line-dimension-value='/usr/local/bin/python3 application.py'
+        """,
+    )
+
+    parser.add_argument(
+        "--target-sha",
+        required=True,
+        help="""
+        The SHA of the commit for the current GitHub workflow run. Used to
+        query Cloudwatch by metric dimension value so metrics returned
+        correspond to the app that was performance tested.
+
+        Examples:
+
+            --target-sha=${{ github.sha }}
+        """,
+    )
+
+    parser.add_argument(
+        "--github-run-id",
+        required=True,
+        help="""
+        The Id for the current GitHub workflow run. Used as a dimension by which
+        metrics are queried in Cloudwatch by so that metrics returned correspond
+        to the correct run of the app that was performance tested.
+
+        Examples:
+
+            --github-run-id=$GITHUB_RUN_ID
+        """,
+    )
+
+
+def get_metric_data_params(args):
+    cpu_load_metric_data_queries = [
+        {
+            "Id": "cpu_time_raw",
+            "MetricStat": {
+                "Metric": {
+                    "Namespace": args.logs_namespace,
+                    "MetricName": "process.cpu.time",
+                    "Dimensions": [
+                        {
+                            "Name": PROCESS_COMMAND_LINE_DIMENSION_NAME,
+                            "Value": args.app_process_command_line_dimension_value,
+                        },
+                        {
+                            "Name": COMMIT_SHA_DIMENSION_NAME,
+                            "Value": args.target_sha,
+                        },
+                        {
+                            "Name": GITHUB_RUN_ID_DIMENSION_NAME,
+                            "Value": args.github_run_id,
+                        },
+                    ],
+                },
+                "Stat": METRIC_DATA_STATISTIC,
+                "Period": args.metrics_period,
+            },
+            "Label": "CPU Time Raw",
+            "ReturnData": False,
+        },
+        {
+            "Id": "cpu_load_expr",
+            "Expression": f"cpu_time_raw/PERIOD(cpu_time_raw)/{args.num_of_cpus}*100",
+            "Label": f"CPU Load Percentage for {args.num_of_cpus} CPUs",
+            "ReturnData": True,
+            "Period": args.metrics_period,
+        },
+    ]
+
+    total_memory_metric_data_queries = [
+        {
+            "Id": "virtual_memory_raw",
+            "MetricStat": {
+                "Metric": {
+                    "Namespace": args.logs_namespace,
+                    "MetricName": "process.memory.virtual_usage",
+                    "Dimensions": [
+                        {
+                            "Name": PROCESS_COMMAND_LINE_DIMENSION_NAME,
+                            "Value": args.app_process_command_line_dimension_value,
+                        },
+                        {
+                            "Name": COMMIT_SHA_DIMENSION_NAME,
+                            "Value": args.target_sha,
+                        },
+                        {
+                            "Name": GITHUB_RUN_ID_DIMENSION_NAME,
+                            "Value": args.github_run_id,
+                        },
+                    ],
+                },
+                "Stat": METRIC_DATA_STATISTIC,
+                "Period": args.metrics_period,
+            },
+            "Label": "Virtual Memory",
+            "ReturnData": False,
+        },
+        {
+            "Id": "physical_memory_raw",
+            "MetricStat": {
+                "Metric": {
+                    "Namespace": args.logs_namespace,
+                    "MetricName": "process.memory.physical_usage",
+                    "Dimensions": [
+                        {
+                            "Name": PROCESS_COMMAND_LINE_DIMENSION_NAME,
+                            "Value": args.app_process_command_line_dimension_value,
+                        },
+                        {
+                            "Name": COMMIT_SHA_DIMENSION_NAME,
+                            "Value": args.target_sha,
+                        },
+                        {
+                            "Name": GITHUB_RUN_ID_DIMENSION_NAME,
+                            "Value": args.github_run_id,
+                        },
+                    ],
+                },
+                "Stat": METRIC_DATA_STATISTIC,
+                "Period": args.metrics_period,
+            },
+            "Label": "Physical Memory",
+            "ReturnData": False,
+        },
+        {
+            "Id": "total_memory_expr",
+            "Expression": "SUM([virtual_memory_raw])",
+            "Label": "Total Memory",
+            "ReturnData": True,
+            "Period": args.metrics_period,
+        },
+    ]
+
+    return cpu_load_metric_data_queries, total_memory_metric_data_queries

--- a/.github/performance-tests/get-metric-data/produce_performance_test_results.py
+++ b/.github/performance-tests/get-metric-data/produce_performance_test_results.py
@@ -1,0 +1,104 @@
+import argparse
+import json
+import logging
+from datetime import datetime, timedelta
+from statistics import mean
+
+import boto3
+
+import metric_data_params
+
+logging.basicConfig(
+    format="%(asctime)-8s %(levelname)-8s %(message)s",
+    level=logging.INFO,
+    datefmt="%FT%TZ",
+)
+
+logger = logging.getLogger(__file__)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="""
+        produce_performance_test_results.py produces overall results for the
+        performance tests that were just run as JSON output.
+        """
+    )
+
+    metric_data_params.add_arguments(parser)
+
+    parser.add_argument(
+        "--test-duration-minutes",
+        required=True,
+        type=int,
+        help="""
+        The duration of the performance test. Used as the starting point for
+        determining which metrics to include in the performance test results.
+
+        Examples:
+
+            --test-duration-minutes=$(echo 1.5 \* 2^30 | bc)
+        """,
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    logger.debug("Starting script to get performance test results.")
+
+    args = parse_args()
+
+    start_time = (
+        datetime.utcnow() - timedelta(minutes=args.test_duration_minutes)
+    ).strftime("%FT%TZ")
+
+    (
+        cpu_load_metric_data_queries,
+        total_memory_metric_data_queries,
+    ) = metric_data_params.get_metric_data_params(args)
+
+    aws_client = boto3.client("cloudwatch")
+
+    metric_data_results = aws_client.get_metric_data(
+        StartTime=start_time,
+        EndTime=datetime.utcnow(),
+        MetricDataQueries=cpu_load_metric_data_queries
+        + total_memory_metric_data_queries,
+    )["MetricDataResults"]
+
+    benchmarks_json = json.dumps(
+        [
+            {
+                "name": "Soak Test Average CPU Load",
+                "value": mean(
+                    next(
+                        metric_data
+                        for metric_data in metric_data_results
+                        if metric_data["Id"] == "cpu_load_expr"
+                    )["Values"]
+                ),
+                "unit": "Percent",
+            },
+            {
+                "name": "Soak Test Average Virtual Memory Used",
+                "value": mean(
+                    next(
+                        metric_data
+                        for metric_data in metric_data_results
+                        if metric_data["Id"] == "total_memory_expr"
+                    )["Values"]
+                )
+                / (2 ** 20),
+                "unit": "Megabytes",
+            },
+        ],
+        indent=4,
+    )
+
+    logger.info("Found these benchmarks: %s", benchmarks_json)
+
+    with open("output.json", "w") as file_context:
+        file_context.write(benchmarks_json)
+
+    logger.info("Done producing Performance Test results.")

--- a/.github/performance-tests/produce_metric_widget_images.py
+++ b/.github/performance-tests/produce_metric_widget_images.py
@@ -1,0 +1,386 @@
+import argparse
+import json
+import logging
+import os
+import shutil
+from heapq import nsmallest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import boto3
+
+logging.basicConfig(
+    format="%(asctime)-8s %(levelname)-8s %(message)s",
+    level=logging.INFO,
+    datefmt="%FT%TZ",
+)
+
+logger = logging.getLogger(__file__)
+
+SOAK_TESTS_SNAPSHOTS_COMMITS_DIR = "soak-tests/snapshots/commits"
+
+# AWS Client API Constants
+
+COMMIT_SHA_DIMENSION_NAME = "commit_sha"
+GITHUB_RUN_ID_DIMENSION_NAME = "github_run_id"
+PROCESS_COMMAND_LINE_DIMENSION_NAME = "process.command_line"
+METRIC_DATA_STATISTIC = "Sum"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="""
+        produce_metric_widget_images.py produces snapshot graphs of the
+        metrics used in the performance tests that were just run.
+        """
+    )
+
+    parser.add_argument(
+        "--cpu-load-threshold",
+        required=True,
+        type=int,
+        help="""
+        The threshold the CPU Load (as a percentage) must stay under to not
+        trigger the alarm.
+
+        Examples:
+
+            --cpu-load-threshold=75
+        """,
+    )
+
+    parser.add_argument(
+        "--total-memory-threshold",
+        required=True,
+        type=int,
+        help="""
+        The threshold the Total Memory (in bytes) must stay under to not trigger
+        the alarm.
+
+        Examples:
+
+            --total-memory-threshold=$(echo 1.5 \* 2^30 | bc)
+        """,
+    )
+
+    parser.add_argument(
+        "--logs-namespace",
+        required=True,
+        help="""
+        The namespace of the logs that the alarm should poll.
+
+        Examples:
+
+            --logs-namespace=aws-observability/aws-otel-python/soak-tests
+        """,
+    )
+
+    parser.add_argument(
+        "--metrics-period",
+        required=True,
+        type=int,
+        help="""
+        The interval at which performance metrics are collected. This is the
+        period used by the metrics that the alarms monitor and is the interval
+        with which the script polls the Performance Test alarms (in seconds).
+
+        Examples:
+
+            --metrics-period=600
+        """,
+    )
+
+    parser.add_argument(
+        "--num-of-cpus",
+        required=True,
+        type=int,
+        help="""
+        The number of CPUs used when running the performance tests.
+
+        Examples:
+
+            --num-of-cpus=2
+        """,
+    )
+
+    parser.add_argument(
+        "--app-process-command-line-dimension-value",
+        required=True,
+        help="""
+        The Cloudwatch metric dimension value which corresponds to the command
+        line string used to run the sample app process. This sample app is the
+        one being tested for performance. The alarms being polled in this script
+        monitor metrics which contain this dimension value.
+
+        Examples:
+
+            --app-process-command-line-dimension-value='/usr/local/bin/python3 application.py'
+        """,
+    )
+
+    parser.add_argument(
+        "--test-duration-minutes",
+        required=True,
+        type=int,
+        help="""
+        The duration of the performance test, which is used to determine the
+        start of metrics to include in the snapshots.
+
+        Examples:
+
+            --test-duration-minutes=$(echo 1.5 \* 2^30 | bc)
+        """,
+    )
+
+    parser.add_argument(
+        "--target-sha",
+        required=True,
+        help="""
+        The SHA of the commit for the current GitHub workflow run. Used to
+        query Cloudwatch by metric dimension value so metrics returned
+        correspond to the app that was performance tested. Also used to create a
+        folder for the snapshot PNG files.
+
+        Examples:
+
+            --target-sha=${{ github.sha }}
+        """,
+    )
+
+    parser.add_argument(
+        "--github-run-id",
+        required=True,
+        help="""
+        The Id for the current GitHub workflow run. Used to create the name of
+        the snapshot PNG file.
+
+        Examples:
+
+            --github-run-id=${GITHUB_RUN_ID}
+        """,
+    )
+
+    parser.add_argument(
+        "--app-platform",
+        required=True,
+        help="""
+        The framework platform for the Sample App which produced the performance
+        metrics. Used to create the name of the snapshot PNG file.
+
+        Examples:
+
+            --app-platform=flask
+        """,
+    )
+
+    parser.add_argument(
+        "--instrumentation-type",
+        required=True,
+        help="""
+        The framework platform for the Sample App which produced the performance
+        metrics. Used to create the name of the snapshot PNG file.
+
+        Examples:
+
+            --instrumentation-type=auto
+        """,
+    )
+
+    parser.add_argument(
+        "--max-benchmarks-to-keep",
+        required=True,
+        type=int,
+        help="""
+        The max number of benchmarks to keep. Used to limit the size of the
+        snapshots/commits folder by deleting older results.
+
+        Examples:
+
+            --max-benchmarks-to-keep=100
+        """,
+    )
+
+    parser.add_argument(
+        "--github-repository",
+        required=True,
+        help="""
+        The repository of the current workflow. Used to generate a log message
+        with the location of the generated snapshot.
+
+        Examples:
+
+            --github-repository=${GITHUB_REPOSITORY}
+        """,
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    logger.debug("Starting script to get performance test results.")
+
+    args = parse_args()
+
+    start_time = (
+        datetime.utcnow() - timedelta(minutes=args.test_duration_minutes)
+    ).strftime("%FT%TZ")
+
+    metric_widget_images = [
+        (
+            "cpu-load",
+            {
+                "metrics": [
+                    [
+                        args.logs_namespace,
+                        "process.cpu.time",
+                        PROCESS_COMMAND_LINE_DIMENSION_NAME,
+                        args.app_process_command_line_dimension_value,
+                        COMMIT_SHA_DIMENSION_NAME,
+                        args.target_sha,
+                        GITHUB_RUN_ID_DIMENSION_NAME,
+                        args.github_run_id,
+                        {
+                            "id": "cpu_time_raw",
+                            "label": "CPU Time Raw",
+                            "visible": False,
+                        },
+                    ],
+                    [
+                        {
+                            "expression": f"cpu_time_raw/PERIOD(cpu_time_raw)/{args.num_of_cpus}*100",
+                            "id": "cpu_load_expr",
+                            "label": f"CPU Load Percentage for {args.num_of_cpus} CPUs",
+                            "color": "#1f77b4",
+                        }
+                    ],
+                    [
+                        {
+                            "expression": f"TIME_SERIES({args.cpu_load_threshold})",
+                            "label": "CPU Threshold",
+                            "id": "cpu_load_threshold",
+                            "color": "#d62728",
+                        }
+                    ],
+                ],
+                "view": "timeSeries",
+                "stacked": False,
+                "stat": METRIC_DATA_STATISTIC,
+                "period": args.metrics_period,
+                "title": f"Process CPU Load Percentage with {args.num_of_cpus} CPUs for ({args.app_platform}, {args.instrumentation_type}) Sample App",
+                "yAxis": {"left": {"label": "Percentage", "showUnits": False}},
+                "liveData": False,
+                "width": 2043,
+                "height": 250,
+                "start": f"-PT{args.test_duration_minutes}M",
+                "end": "P0D",
+            },
+        ),
+        (
+            "total-memory",
+            {
+                "metrics": [
+                    [
+                        args.logs_namespace,
+                        "process.memory.virtual_usage",
+                        PROCESS_COMMAND_LINE_DIMENSION_NAME,
+                        args.app_process_command_line_dimension_value,
+                        COMMIT_SHA_DIMENSION_NAME,
+                        args.target_sha,
+                        GITHUB_RUN_ID_DIMENSION_NAME,
+                        args.github_run_id,
+                        {
+                            "id": "virtual_memory_raw",
+                            "label": "Virtual Memory",
+                            "color": "#ff7f0e",
+                        },
+                    ],
+                    [
+                        ".",
+                        "process.memory.physical_usage",
+                        ".",
+                        ".",
+                        ".",
+                        ".",
+                        ".",
+                        ".",
+                        {
+                            "id": "physical_memory_raw",
+                            "label": "Physical Memory",
+                            "color": "#2ca02c",
+                        },
+                    ],
+                    [
+                        {
+                            "expression": "SUM([virtual_memory_raw])",
+                            "label": "Total Memory (Virtual Memory)",
+                            "id": "total_memory_expr",
+                            "color": "#1f77b4",
+                        }
+                    ],
+                    [
+                        {
+                            "expression": f"TIME_SERIES({args.total_memory_threshold})",
+                            "label": "Total Memory Threshold",
+                            "id": "total_memory_threshold",
+                            "color": "#d62728",
+                        }
+                    ],
+                ],
+                "view": "timeSeries",
+                "stacked": False,
+                "stat": METRIC_DATA_STATISTIC,
+                "period": args.metrics_period,
+                "title": f"Process Memory Usage for ({args.app_platform}, {args.instrumentation_type}) Sample App",
+                "yAxis": {"left": {"showUnits": True}},
+                "liveData": False,
+                "width": 2043,
+                "height": 250,
+                "start": f"-PT{args.test_duration_minutes}M",
+                "end": "P0D",
+            },
+        ),
+    ]
+
+    snapshots_dir = f"{SOAK_TESTS_SNAPSHOTS_COMMITS_DIR}/{ args.target_sha }/runs/{args.github_run_id}/{args.app_platform}"
+
+    Path(snapshots_dir).mkdir(parents=True, exist_ok=True)
+
+    aws_client = boto3.client("cloudwatch")
+
+    for snapshot_type, metric_widget_params in metric_widget_images:
+        metric_widget_image_bytes = aws_client.get_metric_widget_image(
+            MetricWidget=json.dumps(metric_widget_params),
+        )["MetricWidgetImage"]
+
+        snapshot_location = (
+            f"{snapshots_dir}/{args.instrumentation_type}-{snapshot_type}.png"
+        )
+
+        with open(
+            snapshot_location,
+            "wb",
+        ) as file_context:
+            file_context.write(metric_widget_image_bytes)
+
+        logger.info(
+            f"Will create a snapshot at URL: https://github.com/{args.github_repository}/blob/gh-pages/{snapshot_location}",
+        )
+
+    # Delete oldest run folders in most recent commit and oldest commit folders
+
+    for snapshots_dir in [
+        SOAK_TESTS_SNAPSHOTS_COMMITS_DIR,
+        f"{SOAK_TESTS_SNAPSHOTS_COMMITS_DIR}/{ args.target_sha }/runs",
+    ]:
+        snapshot_dirs_length = len(os.listdir(snapshots_dir))
+
+        if snapshot_dirs_length > args.max_benchmarks_to_keep:
+            oldest_snapshot_dirs = nsmallest(
+                snapshot_dirs_length - args.max_benchmarks_to_keep,
+                Path(snapshots_dir).iterdir(),
+                key=os.path.getmtime,
+            )
+            for old_snapshots_dir in oldest_snapshot_dirs:
+                shutil.rmtree(old_snapshots_dir, ignore_errors=True)
+
+    logger.info("Done creating metric widget images.")

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -1,0 +1,237 @@
+# Pre-requisites:
+# - AWS Account with correct permissions
+# - `gh-pages` branch
+# - AWS Account needs to add the LOG_GROUP_NAME defined below
+
+name: Soak Testing
+on:
+  workflow_dispatch:
+    inputs:
+      target_commit_sha:
+        description: 'The commit SHA on this repo to use for the Soak Tests.'
+        required: true
+      test_duration_minutes:
+        description: 'The duration of the Soak Tests in minutes.'
+        required: true
+        default: 300
+  schedule:
+    - cron: '0 15 * * *'
+env:
+  # NOTE: The configuration of `APP_PROCESS_EXECUTABLE_NAME` is repo dependent
+  APP_PROCESS_EXECUTABLE_NAME: EXAMPLE_OF_SOMETHING
+  AWS_DEFAULT_REGION: us-east-1
+  DEFAULT_TEST_DURATION_MINUTES: 300
+  HOSTMETRICS_INTERVAL_SECS: 600
+  CPU_LOAD_THRESHOLD: 50
+  TOTAL_MEMORY_THRESHOLD: 1073741824 # 1 GiB
+  MAX_BENCHMARKS_TO_KEEP: 100
+  LISTEN_ADDRESS_PORT: 8080
+  # TODO: We might be able to adapt the "Soak Tests" to be "Overhead Tests".
+  # This means monitoring the Sample App's performance using high levels of TPS
+  # for the Load Generator over a shorter period of testing time. For example:
+  # https://github.com/aws-observability/aws-otel-collector/blob/main/docs/performance_model.md
+  # THROUGHPUT_PER_SECOND: TBD?
+
+jobs:
+  test_apps_and_publish_results:
+    name: Soak Performance Test - (${{ matrix.app-platform }}, ${{ matrix.instrumentation-type }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+    strategy:
+      fail-fast: false
+      matrix:
+        app-platform: [ rails ]
+        instrumentation-type: [ manual ]
+    env:
+      # NOTE: The configuration of `APP_PATH` is repo dependent
+      APP_PATH: sample-apps
+      LOGS_NAMESPACE: ${{ github.repository }}/soak-tests-${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}
+    steps:
+    # MARK: - GitHub Workflow Event Type Specific Values
+
+      - name: Use INPUT as commit SHA
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "TARGET_SHA=${{ github.event.inputs.target_commit_sha }}" | tee --append $GITHUB_ENV;
+      - name: Use LATEST as commit SHA
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        run: |
+          echo "TARGET_SHA=${{ github.sha }}" | tee --append $GITHUB_ENV;
+      - name: Configure Performance Test Duration
+        run: |
+          echo "TEST_DURATION_MINUTES=${{ github.event.inputs.test_duration_minutes || env.DEFAULT_TEST_DURATION_MINUTES }}" | tee --append $GITHUB_ENV;
+      - name: Clone This Repo @ ${{ env.TARGET_SHA }}
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.TARGET_SHA }}
+
+    # MARK: - Instrumentation-Type Specific Values
+
+      # NOTE: The configuration of `APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE` is
+      # repo dependent
+      - name: Configure Manual Instrumentation-Type Specific Values
+        if: ${{ matrix.instrumentation-type == 'manual' }}
+        run: |
+          echo 'APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE<<EOF' >> $GITHUB_ENV
+          echo 'EXAMPLE_OF_SOMETHING' | tee --append $GITHUB_ENV;
+          echo 'EOF' >> $GITHUB_ENV
+
+    # MARK: - Uniquely identify this Sample App environment
+
+      - name: Create unique combination using matrix + commit parameters
+        run: |
+          echo "MATRIX_COMMIT_COMBO=${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}-${{ env.TARGET_SHA }}" | tee --append $GITHUB_ENV;
+
+    # MARK: - Run Performance Tests
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-duration-seconds: 21600 # 6 Hours
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      - name: Configure Performance Test environment variables
+        run: |
+          echo "NUM_OF_CPUS=$(nproc --all)" | tee --append $GITHUB_ENV;
+      - name: Run All Docker Containers - Sample App + OTel Collector + Load Generator + Alarm Poller
+        id: check-failure-during-performance-tests
+        continue-on-error: true
+        working-directory: .github/docker-performance-tests
+        env:
+          INSTANCE_ID: ${{ github.run_id }}-${{ github.run_number }}
+          LOG_GROUP_NAME: otel-sdk-performance-tests
+          # Also uses:
+          # AWS_ACCESS_KEY_ID
+          # AWS_SECRET_ACCESS_KEY
+          # AWS_SESSION_TOKEN
+          # APP_PATH
+          # TARGET_SHA
+          # LISTEN_ADDRESS_PORT
+          # LOGS_NAMESPACE
+          # APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE
+          # APP_PROCESS_EXECUTABLE_NAME
+          # HOSTMETRICS_INTERVAL_SECS
+          # TEST_DURATION_MINUTES
+          # NUM_OF_CPUS
+          # CPU_LOAD_THRESHOLD
+          # TOTAL_MEMORY_THRESHOLD
+          # AWS_DEFAULT_REGION
+          # MATRIX_COMMIT_COMBO
+          # GITHUB_RUN_ID
+        run: |-
+          docker-compose up --build;
+          RUN_TESTS_EXIT_CODE=$(
+            docker inspect $(
+              docker ps --quiet --all --filter "name=docker-performance-tests_alarms-poller"
+            ) --format="{{.State.ExitCode}}"
+          );
+          echo "RUN_TESTS_EXIT_CODE=$RUN_TESTS_EXIT_CODE" | tee --append $GITHUB_ENV;
+          exit $RUN_TESTS_EXIT_CODE;
+      - name: Fail early if Soak Tests failed to start
+        if: ${{ env.RUN_TESTS_EXIT_CODE == '' || env.RUN_TESTS_EXIT_CODE == 1 }}
+        run: exit 1;
+
+    # MARK: - Report on Performance Test Results
+
+      - name: Install script dependencies
+        run: pip install boto3
+      - name: Get a snapshot of metrics and commit them to the repository
+        run: |
+          python3 .github/scripts/performance-tests/produce_metric_widget_images.py \
+            --logs-namespace ${{ env.LOGS_NAMESPACE }} \
+            --metrics-period ${{ env.HOSTMETRICS_INTERVAL_SECS }} \
+            --num-of-cpus ${{ env.NUM_OF_CPUS }} \
+            --app-process-command-line-dimension-value "${{ env.APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE }}" \
+            --target-sha ${{ env.TARGET_SHA }} \
+            --github-run-id ${GITHUB_RUN_ID} \
+            --test-duration-minutes ${{ env.TEST_DURATION_MINUTES }} \
+            --cpu-load-threshold ${{ env.CPU_LOAD_THRESHOLD }} \
+            --total-memory-threshold ${{ env.TOTAL_MEMORY_THRESHOLD }} \
+            --app-platform ${{ matrix.app-platform }} \
+            --instrumentation-type ${{ matrix.instrumentation-type }} \
+            --max-benchmarks-to-keep ${{ env.MAX_BENCHMARKS_TO_KEEP }} \
+            --github-repository ${GITHUB_REPOSITORY}
+          echo "::warning::Checkout Snapshots at this link: https://github.com/${GITHUB_REPOSITORY}/blob/gh-pages/soak-tests/snapshots/commits/${{ env.TARGET_SHA }}/runs/${GITHUB_RUN_ID}/${{ matrix.app-platform }}";
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com";
+          git config user.name "GitHub Actions";
+          git fetch;
+          git checkout gh-pages;
+          git add soak-tests/snapshots/commits;
+          git commit -m "Soak Test Snapshots from ${{ env.TARGET_SHA }} - ${GITHUB_RUN_ID}";
+          git push;
+          git checkout main;
+      - name: Prepare Performance Test results as JSON output
+        run: python3 .github/scripts/performance-tests/get-metric-data/produce_performance_test_results.py
+          --logs-namespace ${{ env.LOGS_NAMESPACE }}
+          --metrics-period ${{ env.HOSTMETRICS_INTERVAL_SECS }}
+          --num-of-cpus ${{ env.NUM_OF_CPUS }}
+          --app-process-command-line-dimension-value "${{ env.APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE }}"
+          --target-sha ${{ env.TARGET_SHA }}
+          --github-run-id ${GITHUB_RUN_ID}
+          --test-duration-minutes ${{ env.TEST_DURATION_MINUTES }}
+      - name: Do we already have Performance Test graph results for this commit?
+        continue-on-error: true
+        id: check-already-have-performance-results
+        run: |
+          git checkout gh-pages;
+          HAS_RESULTS_ALREADY=$(
+            sed 's/window.BENCHMARK_DATA = //' soak-tests/per-commit-overall-results/data.js |
+            jq "
+              .entries |
+              .\"Soak Test Results - sample-app-${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}\" |
+              any(.commit.id == \"${{ env.TARGET_SHA }}\")
+            " || echo false
+          );
+          git checkout main;
+          [[ $HAS_RESULTS_ALREADY == true ]]
+      - name: Graph and Report Performance Test Averages result
+        uses: benchmark-action/github-action-benchmark@v1
+        continue-on-error: true
+        id: check-failure-after-performance-tests
+        with:
+          name: Soak Test Results - sample-app-${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}
+          tool: customSmallerIsBetter
+          output-file-path: output.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          max-items-in-chart: ${{ env.MAX_BENCHMARKS_TO_KEEP }}
+          alert-threshold: 175%
+          # Does not work as expected, see:
+          # https://github.com/open-telemetry/opentelemetry-python/pull/1478
+          # comment-always: true
+          fail-on-alert: true
+          auto-push: ${{ github.event_name == 'schedule' &&
+            steps.check-already-have-performance-results.outcome == 'failure' &&
+            github.ref == 'refs/heads/main' }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: soak-tests/per-commit-overall-results
+      - name: Publish Issue if failed DURING Performance Tests
+        uses: JasonEtco/create-an-issue@v2
+        if: ${{ github.event_name == 'schedule' &&
+          steps.check-failure-during-performance-tests.outcome == 'failure' }}
+        env:
+          APP_PLATFORM: ${{ matrix.app-platform }}
+          INSTRUMENTATION_TYPE: ${{ matrix.instrumentation-type }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/auto-issue-templates/failure-during-soak_tests.md
+          update_existing: true
+      - name: Publish Issue if failed AFTER Performance Tests
+        uses: JasonEtco/create-an-issue@v2
+        if: ${{ github.event_name == 'schedule' &&
+          steps.check-failure-after-performance-tests.outcome == 'failure' }}
+        env:
+          APP_PLATFORM: ${{ matrix.app-platform }}
+          INSTRUMENTATION_TYPE: ${{ matrix.instrumentation-type }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/auto-issue-templates/failure-after-soak_tests.md
+          update_existing: true
+      - name: Check for Performance Degradation either DURING or AFTER Performance Tests
+        if: ${{ steps.check-failure-during-performance-tests.outcome == 'failure' ||
+          steps.check-failure-after-performance-tests.outcome == 'failure' }}
+        run: >-
+          echo 'Performance Tests failed, see the logs above for details';
+          exit 1;


### PR DESCRIPTION
## Description

Similar to the other ADOT languages repos, we want to add long running Soak Tests to detect:
* Sustained CPU Usage
* Sustained Memory Growth

When we commit these changes, we will be able to see the following items:
* [Graphs showing resource utilization AFTER the Soak Test for every commit](https://aws-observability.github.io/aws-otel-ruby/soak-tests/per-commit-overall-results/index.html)
* [Graphs showing resource utilization DURING the Soak Test for every commit](https://github.com/aws-observability/aws-otel-ruby/tree/gh-pages/soak-tests/snapshots/commits)

**NOTE:** These performance results are still _unreliable_ because they run on GitHub runners which do not have a consistent reproducible environment between runs.

Blocked on: [NathanielRN/aws-otel-ruby#1 - PR to add ADOT Ruby specific values to the Soak Tests](https://github.com/NathanielRN/aws-otel-ruby/pull/1)