### PR TITLE
Create dependatbot file to manage dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 version: 2
 updates:
   - package-ecosystem: 'bundler'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: 'bundler'
+    directory: '/sample-apps/manual-instrumentation/ruby-on-rails'
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    labels:
+      - "ruby dependencies"
+    rebase-strategy: "auto"
+  - package-ecosystem: "github-actions"
+    directory: '/'
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    labels:
+      - "actions"


### PR DESCRIPTION
**Description:** 

Github offers functionality to automatically update dependencies for us. This PR add the dependabot file to the project to update the dependencies and helps with the security updates

More info : https://docs.github.com/en/code-security/dependabot/dependabot-alerts/viewing-and-updating-dependabot-alerts


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
